### PR TITLE
Add specific error related to a username already being taken

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ import aiohttp
 import pytest
 
 from aiowatttime import Client
-from aiowatttime.errors import InvalidCredentialsError, RequestError
+from aiowatttime.errors import InvalidCredentialsError, RequestError, UsernameTakenError
 
 
 @pytest.mark.asyncio
@@ -142,7 +142,7 @@ async def test_register_new_username_fail(aresponses, new_user_fail_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        with pytest.raises(RequestError) as err:
+        with pytest.raises(UsernameTakenError) as err:
             await Client.async_register_new_username(
                 "user",
                 "password",


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a `UsernameTakenError` exception so that consumers of this package can explicitly look for that without having to inspect an exception's message.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
