### PR TITLE
Reorganize how errors are handled

### DIFF
--- a/aiowatttime/errors.py
+++ b/aiowatttime/errors.py
@@ -44,7 +44,7 @@ def raise_client_error(endpoint: str, data: dict[str, Any], err: Exception) -> N
     """Wrap an aiohttp.exceptions.ClientError in the correct exception type."""
     if "message" in data:
         msg = data["message"]
-    elif "error" in data:
+    else:
         msg = data["error"]
 
     try:

--- a/aiowatttime/errors.py
+++ b/aiowatttime/errors.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from aiohttp.client_exceptions import ContentTypeError
-
 
 class WattTimeError(Exception):
     """Define a base exception."""
@@ -42,14 +40,8 @@ ERROR_MESSAGE_TO_EXCEPTION_MAP = {
 }
 
 
-def raise_error(endpoint: str, data: dict[str, Any], err: Exception) -> None:
-    """Return a wrapped error that has the correct info."""
-    if isinstance(err, ContentTypeError):
-        # When the API runs into a credentials issue, it returns NGINX's default
-        # 403 Forbidden HTML, which is an aiohttp.client_exceptions.ContentTypeError
-        # (since we're expecting JSON back):
-        raise InvalidCredentialsError("Invalid credentials") from err
-
+def raise_client_error(endpoint: str, data: dict[str, Any], err: Exception) -> None:
+    """Wrap an aiohttp.exceptions.ClientError in the correct exception type."""
     if "message" in data:
         msg = data["message"]
     elif "error" in data:


### PR DESCRIPTION
**Describe what the PR does:**

This PR streamlines how `aiohttp` errors are handled. `ContentTypeErrors` (related to NGINX HTML responses) are handled earlier and the method to determine a cilent error wrapper is made more explicit.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/aiolookin/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
