### PR TITLE
Make "moer" field optional within RealTimeEmissionsResponseType

### DIFF
--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -48,9 +48,9 @@ class RealTimeEmissionsResponseType(TypedDict):
 
     ba: str
     freq: str
-    moer: float
     percent: int
     point_time: str
+    moer: float | None
 
 
 class EmissionsAPI:


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes the `RealTimeEmissionsResponseType` `TypedDict` to accurately reflect that the `moer` field is optional (as it only exists in PRO subscriptions).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
