### PR TITLE
Add retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ await client.emissions.async_get_historical_emissions(
 ## Retry Logic
 
 By default, `aiowatttime` will handle expired access tokens for you. When a token expires,
-the library will:
+the library will attempt 3 iterations:
 
 * Request a new token
 * Pause for 1 second (to be respectful of the API rate limiting)
-* Attempt the original request again
+* Execute the original request again
 
-By default, this sequence will be attempted 3 times. Both the number of retries and the
-delay between retries can be configured when instantiating a client:
+Both the number of retries and the delay between retries can be configured when
+instantiating a client:
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -152,6 +152,43 @@ await client.emissions.async_get_historical_emissions(
 # >>> [ { "point_time": "2019-02-21T00:15:00.000Z", "value": 844, ... } ]
 ```
 
+## Retry Logic
+
+By default, `aiowatttime` will handle expired token for you. By default, when the library
+encounters such a token, it will:
+
+* Request a new token
+* Pause for 1 second (to be respectful of the API rate limiting)
+* Attempt the original request again
+* Perform the above sequence a total of 3 times
+
+Both the number of retries and the delay between retries can be configured when
+instantiating a client:
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from aiowatttime import Client
+
+
+async def main() -> None:
+    async with ClientSession() as session:
+        client = await Client.async_login(
+            "user",
+            "password",
+            session=session,
+            # Make 7 retry attempts:
+            request_retries=7,
+            # Delay 4 seconds between attempts:
+            request_retry_delay=4,
+        )
+
+
+asyncio.run(main())
+```
+
 # Contributing
 
 1. [Check for open features/bugs](https://github.com/bachya/aiowatttime/issues)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ await client.emissions.async_get_historical_emissions(
 ## Retry Logic
 
 By default, `aiowatttime` will handle expired access tokens for you. When a token expires,
-the library will attempt 3 iterations:
+the library will attempt the following sequence 3 times:
 
 * Request a new token
 * Pause for 1 second (to be respectful of the API rate limiting)

--- a/README.md
+++ b/README.md
@@ -154,16 +154,15 @@ await client.emissions.async_get_historical_emissions(
 
 ## Retry Logic
 
-By default, `aiowatttime` will handle expired token for you. By default, when the library
-encounters such a token, it will:
+By default, `aiowatttime` will handle expired access tokens for you. When a token expires,
+the library will:
 
 * Request a new token
 * Pause for 1 second (to be respectful of the API rate limiting)
 * Attempt the original request again
-* Perform the above sequence a total of 3 times
 
-Both the number of retries and the delay between retries can be configured when
-instantiating a client:
+By default, this sequence will be attempted 3 times. Both the number of retries and the
+delay between retries can be configured when instantiating a client:
 
 ```python
 import asyncio
@@ -188,6 +187,8 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+As always, an invalid username/password combination will immediately throw an exception.
 
 # Contributing
 

--- a/aiowatttime/client.py
+++ b/aiowatttime/client.py
@@ -183,7 +183,7 @@ class Client:
         token_resp = cast(
             TokenResponseType,
             await self._async_request(
-                "get", "login", auth=BasicAuth(self._username, password=self._password),
+                "get", "login", auth=BasicAuth(self._username, password=self._password)
             ),
         )
 


### PR DESCRIPTION
**Describe what the PR does:**

After some tinkering, I've decided that I want to handle some re-auth/retry logic internally to help my consumers out. To that end, this PR:

* raises `InvalidCredentialsException` if we get an `HTTP 403` upon login.
* attempts to refresh an expired token before attempting the request again.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
