### PR TITLE
Add ability to provide a custom logger to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,35 @@ asyncio.run(main())
 
 As always, an invalid username/password combination will immediately throw an exception.
 
+## Custom Logger
+
+By default, `aiowatttime` provides its own logger. If you should wish to use your own, you
+can pass it to the client during instantiation:
+
+```python
+import asyncio
+import logging
+
+from aiohttp import ClientSession
+
+from aiowatttime import Client
+
+CUSTOM_LOGGER = logging.getLogger("my_custom_logger")
+
+
+async def main() -> None:
+    async with ClientSession() as session:
+        client = await Client.async_login(
+            "user",
+            "password",
+            session=session,
+            logger=logger,
+        )
+
+
+asyncio.run(main())
+```
+
 # Contributing
 
 1. [Check for open features/bugs](https://github.com/bachya/aiowatttime/issues)


### PR DESCRIPTION
**Describe what the PR does:**

This PR provides the ability to pass a custom logger to the client during instantiation.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
