### PR TITLE
Add better test for a successfully retried request

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,15 +43,15 @@ def invalid_scope_response_fixture():
 
 
 @pytest.fixture(name="login_response")
-def login_response_fixture(token):
+def login_response_fixture():
     """Define a fixture to return a successful login response."""
-    return {"token": token}
+    return {"token": "abcd1234"}
 
 
 @pytest.fixture(name="new_user_success_response")
-def new_user_success_response_fixture(username):
+def new_user_success_response_fixture():
     """Define a fixture to return a successful new user registration response."""
-    return {"user": username, "ok": "User created"}
+    return {"user": "user", "ok": "User created"}
 
 
 @pytest.fixture(name="new_user_fail_response", scope="session")
@@ -70,15 +70,3 @@ def password_reset_fail_response_fixture():
 def realtime_emissions_response_fixture():
     """Define a fixture to return a realtime emissions response."""
     return json.loads(load_fixture("realtime_emissions_response.json"))
-
-
-@pytest.fixture(name="token")
-def token_fixture():
-    """Define a fixture to return a token."""
-    return "abcd1234"
-
-
-@pytest.fixture(name="username")
-def username_fixture():
-    """Define a fixture to return a username."""
-    return "user"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -262,7 +262,7 @@ async def test_successful_token_refresh(
         ),
     )
 
-    # Simulate getting a different token upon the next login
+    # Simulate getting a different token upon the next login:
     login_response["token"] = "efgh5678"
 
     aresponses.add(


### PR DESCRIPTION
**Describe what the PR does:**

The bugfix in https://github.com/bachya/aiowatttime/pull/11 revelead that the existing test for a successfully retried request was faulty (because we merely assumed a successful response body). This PR updates things to actually test for the condition that https://github.com/bachya/aiowatttime/pull/11 fixed.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
