### PR TITLE
Create decorator to check for date time consistency

### DIFF
--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -59,7 +59,7 @@ def ensure_start_and_end_datetime():
     def decorator(func: Awaitable):
         """Decorate."""
 
-        def wrapper(*args, start_datetime=None, end_datetime=None, **kwargs):
+        async def wrapper(*args, start_datetime=None, end_datetime=None, **kwargs):
             """Wrap."""
             if ~(bool(start_datetime) ^ bool(end_datetime)) == -1:
                 # This is a form of XNOR that handles None-type values; if the user

--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -61,7 +61,7 @@ def ensure_start_and_end_datetime():
 
         async def wrapper(*args, **kwargs):
             """Wrap."""
-            if ~(bool(start_datetime) ^ bool(end_datetime)) == -1:
+            if ~(bool(kwargs["start_datetime"]) ^ bool(kwargs["end_datetime"])) == -1:
                 # This is a form of XNOR that handles None-type values; if the user
                 # provides none or both of start_datetime and end_datetime, we're good:
                 return await func(*args, **kwargs)

--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -64,12 +64,7 @@ def ensure_start_and_end_datetime():
             if ~(bool(start_datetime) ^ bool(end_datetime)) == -1:
                 # This is a form of XNOR that handles None-type values; if the user
                 # provides none or both of start_datetime and end_datetime, we're good:
-                return await func(
-                    *args,
-                    start_datetime=start_datetime,
-                    end_datetime=end_datetime,
-                    **kwargs
-                )
+                return await func(*args, **kwargs)
 
             # ...otherwise, raise an error:
             raise ValueError("start_datetime and end_datetime must go together")

--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -62,7 +62,7 @@ def ensure_start_and_end_datetime():
         def wrapper(*args, start_datetime=None, end_datetime=None, **kwargs):
             """Wrap."""
             if ~(bool(start_datetime) ^ bool(end_datetime)) == -1:
-                # This is a form of XNOR that "handles" None-type values - if the user
+                # This is a form of XNOR that handles None-type values; if the user
                 # provides none or both of start_datetime and end_datetime, we're good:
                 return await func(
                     *args,

--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -59,7 +59,7 @@ def ensure_start_and_end_datetime():
     def decorator(func: Awaitable):
         """Decorate."""
 
-        async def wrapper(*args, start_datetime=None, end_datetime=None, **kwargs):
+        async def wrapper(*args, **kwargs):
             """Wrap."""
             if ~(bool(start_datetime) ^ bool(end_datetime)) == -1:
                 # This is a form of XNOR that handles None-type values; if the user


### PR DESCRIPTION
**Describe what the PR does:**

We had some duplicated code to ensure that `start_datetime` and `end_datetime` were always paired together properly. This PR simplifies things into a single decorator.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
