### PR TITLE
Simplify datetime usage in emissions endpoints

### DIFF
--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -77,9 +77,6 @@ class EmissionsAPI:
         end_datetime: datetime | None = None,
     ) -> RealTimeEmissionsResponseType:
         """Return the forecasted emissions for a latitude/longitude."""
-        if start_datetime and not end_datetime or end_datetime and not start_datetime:
-            raise ValueError("You must provided start and end datetimes together")
-
         params = {"ba": balancing_authority_abbreviation}
         if start_datetime and end_datetime:
             params["starttime"] = start_datetime.isoformat()
@@ -98,9 +95,6 @@ class EmissionsAPI:
         moer_version: str = DEFAULT_MOER_VERSION,
     ) -> HistoricalEmissionsResponseType:
         """Return the historical emissions for a latitude/longitude."""
-        if start_datetime and not end_datetime or end_datetime and not start_datetime:
-            raise ValueError("You must provided start and end datetimes together")
-
         params = {"latitude": latitude, "longitude": longitude, "version": moer_version}
         if start_datetime and end_datetime:
             params["starttime"] = start_datetime.isoformat()


### PR DESCRIPTION
**Describe what the PR does:**

I was overdoing my checks to ensure that emissions API endpoints were using dates correctly. This PR simplifies things:

* if a user provides a start datetime _and_ and end datetime to the appropriate endpoint, use them.
* if not (including if they use one but not the other), don't use them.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
