### PR TITLE
Fix missing signal parameter & minor readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ from aiowatttime import Client
 
 
 async def main() -> None:
-    client = await Client.login("<USERNAME>", "<PASSWORD>")
+    client = await Client.async_login("<USERNAME>", "<PASSWORD>")
     # ...
 
 
@@ -78,7 +78,7 @@ from aiowatttime import Client
 
 async def main() -> None:
     async with ClientSession() as session:
-        client = await Client.login("<USERNAME>", "<PASSWORD>", session=session)
+        client = await Client.async_login("<USERNAME>", "<PASSWORD>", session=session)
         # ...
 
 
@@ -110,7 +110,7 @@ Getting emissions data will require the region abbreviation (`PSCO` in the examp
 ### Realtime Data
 
 ```python
-await client.emissions.async_get_realtime_emissions("<REGION>")
+await client.emissions.async_get_realtime_emissions("<REGION>", "<SIGNAL_TYPE>")
 # >>>
 {"data": [...]}
 ```
@@ -118,10 +118,13 @@ await client.emissions.async_get_realtime_emissions("<REGION>")
 ### Forecasted Data
 
 ```python
-from datetime import datetime
+from datetime import datetime, timezone
 
 await client.emissions.async_get_forecasted_emissions(
-    "<REGION>", "<SIGNAL_TYPE>", datetime(2021, 1, 1), datetime(2021, 2, 1)
+    "<REGION>",
+    "<SIGNAL_TYPE>",
+    datetime(2021, 1, 1, tzinfo=timezone.utc),
+    datetime(2021, 2, 1, tzinfo=timezone.utc),
 )
 # >>> { "data": [ ... ] }
 ```
@@ -129,8 +132,13 @@ await client.emissions.async_get_forecasted_emissions(
 ### Historical Data
 
 ```python
-await client.emissions.async_get_forecasted_emissions(
-    "<REGION>", "<SIGNAL_TYPE>", datetime(2021, 1, 1), datetime(2021, 2, 1)
+from datetime import datetime, timezone
+
+await client.emissions.async_get_historical_emissions(
+    "<REGION>",
+    "<SIGNAL_TYPE>",
+    datetime(2021, 1, 1, tzinfo=timezone.utc),
+    datetime(2021, 2, 1, tzinfo=timezone.utc),
 )
 # >>> [ { "point_time": "2019-02-21T00:15:00.000Z", "value": 844, ... } ]
 ```

--- a/aiowatttime/emissions.py
+++ b/aiowatttime/emissions.py
@@ -101,11 +101,14 @@ class EmissionsAPI:
             },
         )
 
-    async def async_get_realtime_emissions(self, region: str) -> dict[str, Any]:
+    async def async_get_realtime_emissions(
+        self, region: str, signal_type: str
+    ) -> dict[str, Any]:
         """Return the realtime emissions for a region.
 
         Args:
             region: The abbreviated form of a region.
+            signal_type: The signal type.
 
         Returns:
             An API response payload.
@@ -115,5 +118,6 @@ class EmissionsAPI:
             "v3/signal-index",
             params={
                 "region": region,
+                "signal_type": signal_type,
             },
         )

--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -14,6 +14,7 @@ USERNAME = "<USERNAME>"
 PASSWORD = "<PASSWORD>"  # noqa: S105
 
 REGION = "PSCO"
+SIGNAL_TYPE = "co2_moer"
 
 
 async def main() -> None:
@@ -22,7 +23,9 @@ async def main() -> None:
     async with ClientSession() as session:
         try:
             client = await Client.async_login(USERNAME, PASSWORD, session=session)
-            realtime_data = await client.emissions.async_get_realtime_emissions(REGION)
+            realtime_data = await client.emissions.async_get_realtime_emissions(
+                REGION, SIGNAL_TYPE
+            )
             _LOGGER.info(realtime_data)
         except WattTimeError as err:
             _LOGGER.error("There was an error: %s", err)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -129,11 +129,11 @@ async def test_expired_token(
             )
 
             # Simulate request #1 having a working token:
-            await client.emissions.async_get_realtime_emissions("PSCO")
+            await client.emissions.async_get_realtime_emissions("PSCO", "co2_moer")
 
             # Simulate request #2 having an expired token:
             with pytest.raises(InvalidCredentialsError):
-                await client.emissions.async_get_realtime_emissions("PSCO")
+                await client.emissions.async_get_realtime_emissions("PSCO", "co2_moer")
 
     aresponses.assert_plan_strictly_followed()
 
@@ -354,7 +354,7 @@ async def test_successful_token_refresh(
 
             # If we get past here without raising an exception, we know the refresh
             # worked:
-            await client.emissions.async_get_realtime_emissions("PSCO")
+            await client.emissions.async_get_realtime_emissions("PSCO", "co2_moer")
 
         # Verify that the token actually changed between retries of /v3/signal-index:
         history = authenticated_watttime_api_server.history

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -164,7 +164,7 @@ async def test_get_historical_emissions(
         async with aiohttp.ClientSession() as session:
             client = await Client.async_login("user", "password", session=session)
             historical_data = await client.emissions.async_get_historical_emissions(
-                "PSCO", "c02_moer", datetime(2021, 3, 1), datetime(2021, 3, 31)
+                "PSCO", "co2_moer", datetime(2021, 3, 1), datetime(2021, 3, 31)
             )
             assert len(historical_data) == 2
 
@@ -196,7 +196,9 @@ async def test_get_realtime_emissions(
 
         async with aiohttp.ClientSession() as session:
             client = await Client.async_login("user", "password", session=session)
-            realtime_data = await client.emissions.async_get_realtime_emissions("PSCO")
+            realtime_data = await client.emissions.async_get_realtime_emissions(
+                "PSCO", "co2_moer"
+            )
             assert realtime_data == {
                 "data": [{"point_time": "2024-06-18T18:40:00+00:00", "value": 96.0}],
                 "meta": {
@@ -240,7 +242,7 @@ async def test_invalid_scope(
 
             with pytest.raises(InvalidScopeError):
                 await client.emissions.async_get_forecasted_emissions(
-                    "PSCO", "c02_moer", datetime(2021, 1, 1), datetime(2021, 2, 1)
+                    "PSCO", "co2_moer", datetime(2021, 1, 1), datetime(2021, 2, 1)
                 )
 
     aresponses.assert_plan_strictly_followed()


### PR DESCRIPTION
**Describe what the PR does:**

* Add missing `signal_type` parameter to `async_get_realtime_emissions()` (required by the API but missing from the function signature, causing failures)
* Fix README examples:

  * `Client.login()` → `Client.async_login()`
  * Add missing `signal_type` argument to `async_get_realtime_emissions()`
  * Correct historical data example (was using `async_get_forecasted_emissions` instead of `async_get_historical_emissions`)
  * Add `timezone.utc` to all `datetime` arguments

Revives work originally implemented by @bachya in a now-stale PR #407 

This change is likely required as a fix for the WattTime integration for Home Assistant (see: [https://github.com/home-assistant/core/issues/136595](https://github.com/home-assistant/core/issues/136595)).

---

**Does this fix a specific issue?**

UI was unable to find the original issue cited in the stale pull request (#407). This issue prevents the real-time emissions function from being useable.

---

**Checklist:**

* [ ] Confirm that one or more new tests are written for the new functionality.
* [x] Run tests and ensure everything passes (with 100% test coverage).
* [x] Update `README.md` with any new documentation.
